### PR TITLE
Fix OnStopScrolling not called on iOS

### DIFF
--- a/Sharpnado.HorizontalListView.iOS/Renderers/HorizontalList/iOSHorizontalListViewRenderer.ScrollDelegates.cs
+++ b/Sharpnado.HorizontalListView.iOS/Renderers/HorizontalList/iOSHorizontalListViewRenderer.ScrollDelegates.cs
@@ -216,6 +216,14 @@ namespace Sharpnado.HorizontalListView.iOS.Renderers.HorizontalList
             _isScrolling = true;
             Element.ScrollBeganCommand?.Execute(null);
         }
+        
+        private void OnStopScrollingByUserAction(object sender, DraggingEventArgs e)
+        {
+            if (!e.Decelerate)
+            {
+                OnStopScrolling(sender, e);
+            }
+        }
 
         private void OnStopScrolling(object sender, EventArgs e)
         {

--- a/Sharpnado.HorizontalListView.iOS/Renderers/HorizontalList/iOSHorizontalListViewRenderer.cs
+++ b/Sharpnado.HorizontalListView.iOS/Renderers/HorizontalList/iOSHorizontalListViewRenderer.cs
@@ -104,6 +104,7 @@ namespace Sharpnado.HorizontalListView.iOS.Renderers.HorizontalList
                     Control.DecelerationEnded -= OnStopScrolling;
                     Control.ScrollAnimationEnded -= OnStopScrolling;
                     Control.Scrolled -= OnScrolled;
+                    Control.DraggingEnded -= OnStopScrollingByUserAction;
 
                     Control.DraggingEnded -= OnDraggingEnded;
                     Control.DecelerationEnded -= OnDecelerationEnded;
@@ -229,6 +230,7 @@ namespace Sharpnado.HorizontalListView.iOS.Renderers.HorizontalList
             Control.Scrolled += OnScrolled;
             Control.ScrollAnimationEnded += OnStopScrolling;
             Control.DecelerationEnded += OnStopScrolling;
+            Control.DraggingEnded += OnStopScrollingByUserAction;
 
             EnableDragAndDrop(Element.EnableDragAndDrop, Element.DragAndDropTrigger);
 


### PR DESCRIPTION
StopScrolling is not always called on iOS. The current implementation calls StopScrolling only if deceleration ends. To call StopScrolling if the user touch, move, stop move and release his finger we must use DraggingEnded.
Problem is described here:
https://stackoverflow.com/questions/14868269/uicollectionview-how-to-detect-when-scrolling-has-stopped
and solution:
https://stackoverflow.com/a/19573905/4506984